### PR TITLE
fix: Spinner padding

### DIFF
--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -97,10 +97,10 @@ template BavarderWindow : Adw.ApplicationWindow {
                 tooltip-text: _("Wait");
                 styles ["suggested-action", "circular"]
                 Spinner spinner {
-                  margin-top: 6;
-                  margin-bottom: 6;
-                  margin-start: 6;
-                  margin-end: 6;
+                  margin-top: 8;
+                  margin-bottom: 8;
+                  margin-start: 8;
+                  margin-end: 8;
                   styles ["suggested-action", "circular"]
                 }
               }


### PR DESCRIPTION
Make it match spinner in GNOME Control Center

![image](https://user-images.githubusercontent.com/77155297/234948414-65a1e5f4-bd54-4964-9bec-01fa9f403177.png)