### PR TITLE
Removed private mail

### DIFF
--- a/po/hu.po
+++ b/po/hu.po
@@ -6,7 +6,6 @@
 # osiixy <osiixy@gmail.com>, 2023.
 # 0xMRTT <0xmrtt@proton.me>, 2023.
 # elementbound <ezittgtx@gmail.com>, 2023.
-# ViBE <vibe@hotmail.hu>, 2023.
 # ViBE <vibe@protonmail.com>, 2023.
 msgid ""
 msgstr ""


### PR DESCRIPTION
I have no such clue why is it so hard for codeberg(?) to identify the same user with different mails but it cannot handle the fact that i changed my mail address in my account. my registration is not new but looks like there is a configuration problem with this project and i cannot select my contribution mail address if it is not set as primary address. weblate can do this. now i had to set my not main address to temporary fix this.

so please check the codeberg/weblate translation configurations and remove somehow my .hu mail. thanks.