### PR TITLE
Add support for Azure OpenAI, Palm, Claude, Cohere, Replicate, Sagemaker (100+LLMs) - using litellm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ idna
 urllib3
 Babel
 openai
+litellm

--- a/src/providers/openai.py
+++ b/src/providers/openai.py
@@ -2,6 +2,7 @@ from .base import BaseProvider
 
 import openai
 import socket
+from litellm import completion
 
 from gi.repository import Gtk, Adw, GLib
 
@@ -23,16 +24,18 @@ class BaseOpenAIProvider(BaseProvider):
         chat = chat["content"]
 
         if self.data.get("api_key"):
-            openai.api_key = self.data["api_key"]
+            api_key = self.data["api_key"]
         if self.data.get("api_base"):
-            openai.api_base = self.data["api_base"]
+            api_base = self.data["api_base"]
 
         if self.model:
             prompt = self.chunk(prompt)
             try:
-                response = self.chat.create(
+                response = completion(
                             model=self.model,
                             messages=chat,
+                            api_key=api_key,
+                            api_base=api_base,
                         ).choices[0].message.content
             except openai.error.AuthenticationError:
                 return _("Your API key is invalid, please check your preferences.")


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 


Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```