### PR TITLE
Fixed a missing import of openai in the local provider.

### DIFF
--- a/src/providers/local.py
+++ b/src/providers/local.py
@@ -1,4 +1,5 @@
 from .openai import BaseOpenAIProvider
+import openai
 
 from gi.repository import Gtk, Adw
 


### PR DESCRIPTION
This fixes #51 which has the error shown below. This makes it so that the parameters of the local provider are correctly saved and I tested it works with a docker container running gtp4all. I also tested that it did not work before the change (even when compiled from source in Builder)

```
Traceback (most recent call last):
  File "/app/share/bavarder/bavarder/providers/local.py", line 39, in on_apply
    openai.api_key = api_key
    ^^^^^^
NameError: name 'openai' is not defined. Did you mean: 'open'?
```